### PR TITLE
Update random when assign uses update DB

### DIFF
--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -230,7 +230,8 @@ def assign_query(dbFuncs,
             sys.stderr.write("Updating reference database to " + output + "\n")
 
         # Update the network + ref list (everything)
-        joinDBs(ref_db, output, output)
+        joinDBs(ref_db, output, output,
+                {"threads": threads, "strand_preserved": strand_preserved})
         if model.type == 'lineage':
             genomeNetwork[min(model.ranks)].save(output + "/" + os.path.basename(output) + '_graph.gt', fmt = 'gt')
         else:

--- a/scripts/poppunk_db_info.py
+++ b/scripts/poppunk_db_info.py
@@ -31,12 +31,6 @@ if __name__ == "__main__":
     sketch_version = ref_db['sketches'].attrs['sketch_version']
     print("Sketch version:\t\t\t" + sketch_version)
 
-    if 'random' in ref_db.keys():
-        has_random = True
-    else:
-        has_random = False
-    print("Contains random matches:\t" + str(has_random))
-
     num_samples = len(ref_db['sketches'].keys())
     print("Number of samples:\t\t" + str(num_samples))
 
@@ -47,19 +41,28 @@ if __name__ == "__main__":
     sketch_size = int(ref_db['sketches/' + first_sample].attrs['sketchsize64']) * 64
     print("Sketch size:\t\t\t" + str(sketch_size))
 
+    if 'random' in ref_db.keys():
+        has_random = True
+    else:
+        has_random = False
+    print("Contains random matches:\t" + str(has_random))
+
+    try:
+        codon_phased = ref_db['sketches'].attrs['codon_phased'] == 1
+    except KeyError:
+        codon_phased = False
+    print("Codon phased seeds:\t\t" + str(codon_phased))
+
     if args.list_samples:
-        print("\nSamples:")
+        print("\n")
+        print("\t".join(["name", "base_frequencies", "length", "missing_bases"]))
         for sample_name in list(ref_db['sketches'].keys()):
-            print("Name:\t" + sample_name)
-
+            sample_string = [sample_name]
             base_freq = ref_db['sketches/' + sample_name].attrs['base_freq']
-            print("\tBase frequencies:\t" + ",".join([base + ':' + str(x) for base, x in zip(['A', 'C', 'G', 'T'], base_freq)]))
-
-            length = ref_db['sketches/' + sample_name].attrs['length']
-            print("\tLength:\t\t\t" + str(length))
-
-            missing = ref_db['sketches/' + sample_name].attrs['missing_bases']
-            print("\tMissing bases:\t\t" + str(missing))
+            sample_string.append(",".join([base + ':' + "{:.3f}".format(x) for base, x in zip(['A', 'C', 'G', 'T'], base_freq)]))
+            sample_string.append(str(ref_db['sketches/' + sample_name].attrs['length']))
+            sample_string.append(str(ref_db['sketches/' + sample_name].attrs['missing_bases']))
+            print("\t".join(sample_string))
 
 
     sys.exit(0)


### PR DESCRIPTION
This is fixed in sketchlib 1.6.5 (https://github.com/johnlees/pp-sketchlib/pull/56), but this automates the refresh of random matches when using `--update-db`