### PR TITLE
Move the extend algorithm into the C++ extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library("${TARGET_NAME}" MODULE)
 
 # Compile CPU library
 target_sources("${TARGET_NAME}" PRIVATE src/python_bindings.cpp
-                                        src/boundary.cpp)
+                                        src/boundary.cpp
+                                        src/extend.cpp)
 
 set_target_properties("${TARGET_NAME}" PROPERTIES
     CXX_VISIBILITY_PRESET "hidden"

--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.4.3'
+__version__ = '2.4.4'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 1

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -1016,7 +1016,7 @@ class LineageFit(ClusterFit):
         '''
         # Check if model requires GPU
         check_and_set_gpu(self.use_gpu, gpu_lib, quit_on_fail = True)
-        
+
         ClusterFit.fit(self, X)
         sample_size = int(round(0.5 * (1 + np.sqrt(1 + 8 * X.shape[0]))))
         if (max(self.ranks) >= sample_size):
@@ -1160,7 +1160,7 @@ class LineageFit(ClusterFit):
         if self.use_gpu:
             qqDists = cp.array(qqDists)
             qrDists = cp.array(qrDists)
-    
+
         # Reshape qq and qr dist matrices
         qqSquare = pp_sketchlib.longToSquare(qqDists[:, [self.dist_col]], self.threads)
         qqSquare[qqSquare < epsilon] = epsilon

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -1169,7 +1169,7 @@ class LineageFit(ClusterFit):
 
         n_ref = self.nn_dists[self.ranks[0]].shape[0]
         n_query = qqSquare.shape[1]
-        qrRect = qrDists[:, [self.dist_col]].reshape(n_query, n_ref)
+        qrRect = qrDists[:, [self.dist_col]].reshape(n_query, n_ref).T
         qrRect[qrRect < epsilon] = epsilon
 
         max_rank = max(self.ranks)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -1203,9 +1203,10 @@ class LineageFit(ClusterFit):
 
         with Pool(processes=self.threads) as pool:
             pool.map(partial(self.__reduce_rank__,
-                             higher_rank_sparse_mat = higher_rank,
-                             n_samples = n_ref + n_query,
-                             dtype = rrSparse.dtype),
+                             self=self,
+                             higher_rank_sparse_mat=higher_rank,
+                             n_samples=n_ref + n_query,
+                             dtype=rrSparse.dtype),
                      sorted(self.ranks, reverse=True)[1:])
 
         y = self.assign(min(self.ranks))

--- a/src/boundary.cpp
+++ b/src/boundary.cpp
@@ -4,17 +4,12 @@
  * Functions to move a network boundary
  *
  */
-#include <algorithm>
 #include <cassert> // assert
 #include <cmath>   // floor/sqrt
 #include <cstddef> // size_t
 #include <cstdint>
-#include <numeric>
 #include <string>
 #include <vector>
-
-// Parallel sort
-#include <boost/sort/sort.hpp>
 
 #include "boundary.hpp"
 
@@ -39,20 +34,6 @@ inline size_t square_to_condensed(const size_t i, const size_t j,
                                   const size_t n) {
   assert(j > i);
   return (n * i - ((i * (i + 1)) >> 1) + j - 1 - i);
-}
-
-// https://stackoverflow.com/a/12399290
-template <typename T>
-std::vector<long> sort_indexes(const T &v, const uint32_t n_threads) {
-  // initialize original index locations
-  std::vector<long> idx(v.size());
-  std::iota(idx.begin(), idx.end(), 0);
-
-  boost::sort::parallel_stable_sort(
-      idx.begin(), idx.end(), [&v](long i1, long i2) { return v[i1] < v[i2]; },
-      n_threads);
-
-  return idx;
 }
 
 // Unnormalised (signed_ distance between a point (x0, y0) and a line defined

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -10,17 +10,32 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <algorithm>
+#include <numeric>
 
 #include <Eigen/Dense>
 
+// Parallel sort
+#include <boost/sort/sort.hpp>
 typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     NumpyMatrix;
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<long>>
     network_coo;
 typedef std::vector<std::tuple<long, long>> edge_tuple;
 
+// https://stackoverflow.com/a/12399290
 template <typename T>
-std::vector<long> sort_indexes(const T &v, const uint32_t n_threads);
+std::vector<long> sort_indexes(const T &v, const uint32_t n_threads) {
+  // initialize original index locations
+  std::vector<long> idx(v.size());
+  std::iota(idx.begin(), idx.end(), 0);
+
+  boost::sort::parallel_stable_sort(
+      idx.begin(), idx.end(), [&v](long i1, long i2) { return v[i1] < v[i2]; },
+      n_threads);
+
+  return idx;
+}
 
 Eigen::VectorXf assign_threshold(const NumpyMatrix &distMat, const int slope,
                                  const float x_max, const float y_max,

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -17,7 +17,12 @@ typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     NumpyMatrix;
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<long>>
     network_coo;
+typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>>
+    sparse_coo;
 typedef std::vector<std::tuple<long, long>> edge_tuple;
+
+template <typename T>
+std::vector<long> sort_indexes(const T &v, const uint32_t n_threads)
 
 Eigen::VectorXf assign_threshold(const NumpyMatrix &distMat, const int slope,
                                  const float x_max, const float y_max,

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -17,12 +17,10 @@ typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     NumpyMatrix;
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<long>>
     network_coo;
-typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>>
-    sparse_coo;
 typedef std::vector<std::tuple<long, long>> edge_tuple;
 
 template <typename T>
-std::vector<long> sort_indexes(const T &v, const uint32_t n_threads)
+std::vector<long> sort_indexes(const T &v, const uint32_t n_threads);
 
 Eigen::VectorXf assign_threshold(const NumpyMatrix &distMat, const int slope,
                                  const float x_max, const float y_max,

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -1,7 +1,7 @@
 /*
  *
- * matrix.hpp
- * functions in matrix_ops.cpp
+ * boundary.hpp
+ * prototypes for boundary fns
  *
  */
 #pragma once

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -35,7 +35,7 @@ std::vector<T> combine_vectors(const std::vector<std::vector<T>> &vec,
   std::vector<T> all(len);
   auto all_it = all.begin();
   for (size_t i = 0; i < vec.size(); ++i) {
-    std::copy(vec[i].cbegin(), vec[i].cend(); all_it);
+    std::copy(vec[i].cbegin(), vec[i].cend(), all_it);
     all_it += vec[i].size();
   }
   return all;

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -37,9 +37,6 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
   std::vector<long> row_start_idx =
       row_start_indices(sparse_rr_mat, nr_samples);
 
-  std::cout << qq_mat_square << std::endl;
-  std::cout << qr_mat_rect << std::endl;
-
   // ijv vectors
   std::vector<float> dists;
   std::vector<long> i_vec;
@@ -63,12 +60,6 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
     // Sort these. Then do a merge below
     std::vector<long> qr_ordered_idx = sort_indexes(qr_dists, 1);
     std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
-    for (int z = 0; z < qr_ordered_idx.size(); ++z) {
-      std::cout << z << "\t" << qr_ordered_idx[z] << "\t" << qr_dists[qr_ordered_idx[z]] << std::endl;
-    }
-    for (int z = 0; z < rr_ordered_idx.size(); ++z) {
-      std::cout << z << "\t" << rr_ordered_idx[z] << "\t" << rr_dists[rr_ordered_idx[z]] << std::endl;
-    }
 
     // See sparsify_dists in pp_sketchlib.
     // This is very similar, but merging two lists as input

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -87,7 +87,7 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
         dist = qr_dists[*qr_it];
         ++qr_it;
       } else {
-        j = *rr_it;
+        j = std::get<1>(sparse_rr_mat)[row_start_idx[i] + *rr_it];
         dist = rr_dists[*rr_it];
         ++rr_it;
       }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -37,6 +37,9 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
   std::vector<long> row_start_idx =
       row_start_indices(sparse_rr_mat, nr_samples);
 
+  std::cout << qq_mat_square << std::endl;
+  std::cout << qr_mat_rect << std::endl;
+
   // ijv vectors
   std::vector<float> dists;
   std::vector<long> i_vec;
@@ -60,6 +63,12 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
     // Sort these. Then do a merge below
     std::vector<long> qr_ordered_idx = sort_indexes(qr_dists, 1);
     std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
+    for (int z = 0; z < qr_ordered_idx.size(); ++z) {
+      std::cout << z << "\t" << qr_ordered_idx[z] << "\t" << qr_dists[qr_ordered_idx[z]] << std::endl;
+    }
+    for (int z = 0; z < rr_ordered_idx.size(); ++z) {
+      std::cout << z << "\t" << rr_ordered_idx[z] << "\t" << rr_dists[rr_ordered_idx[z]] << std::endl;
+    }
 
     // See sparsify_dists in pp_sketchlib.
     // This is very similar, but merging two lists as input

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -87,7 +87,11 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_squ
         dist = qr_dists[*qr_it];
         ++qr_it;
       } else {
-        j = std::get<1>(sparse_rr_mat)[row_start_idx[i] + *rr_it];
+        if (i < nr_samples) {
+          j = std::get<1>(sparse_rr_mat)[row_start_idx[i] + *rr_it];
+        } else {
+          j = *rr_it;
+        }
         dist = rr_dists[*rr_it];
         ++rr_it;
       }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1,0 +1,101 @@
+/*
+ *
+ * extend.cpp
+ * Functions to extend a sparse distance matrix
+ *
+ */
+#include <algorithm>
+#include <cassert> // assert
+#include <cmath>   // floor/sqrt
+#include <cstddef> // size_t
+#include <cstdint>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "boundary.hpp"
+
+sparse_coo extend(const sparse_coo &sparse_rr_mat,
+                  const NumpyMatrix &qq_mat_square,
+                  const NumpyMatrix &qr_mat_rect, const size_t kNN) {
+  const size_t nr_samples = qr_mat_rect.rows();
+  const size_t nq_samples = qr_mat_rect.cols();
+
+  // Get indices where each row starts in the sparse matrix
+  const std::vector<long> i_vec = std::get<0>(sparse_rr_mat);
+  std::vector<long> row_start_idx(nr_samples + 1);
+  size_t i_idx = 0;
+  row_start_idx[0] = 0;
+  row_start_idx[nr_samples] = i_vec.size();
+  for (long i = 1; i < nr_samples; ++i) {
+    while (i_vec[i_idx] < i) {
+      i_idx++;
+    }
+    row_start_idx[i] = i_idx;
+  }
+
+  // ijv vectors
+  std::vector<float> dists;
+  std::vector<long> i_vec;
+  std::vector<long> j_vec;
+  const std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
+  for (long i = 0; i < nr_samples + nq_samples; ++i) {
+    // Extract the dists for the row from the qr (dense) and rr (sparse)
+    // matrices
+    Eigen::VectorXf rr_dists, qr_dists;
+    if (i < nr_samples) {
+      qr_dists = qr_mat_rect.row(i);
+      Eigen::Map<Eigen::VectorXf> rr_map(dist_vec.data() + row_start_idx[i],
+                                           row_start_idx[i + 1] -
+                                               row_start_idx[i]);
+      rr_dists = rr_map;
+    } else {
+      rr_dists = qr_mat_rect.col(i - nr_samples);
+      qr_dists = qq_mat_square.row(i - nr_samples);
+    }
+
+    // Sort these. Then do a merge
+    std::vector<long> qr_ordered_idx = sort_indexes(qr_dists, 1);
+    std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
+
+    long unique_neighbors = 0;
+    float prev_value = -1;
+    auto rr_it = rr_ordered_idx.cbegin();
+    auto qr_it = qr_ordered_idx.cbegin();
+    while (qr_it != qr_ordered_idx.cend() && rr_it != rr_ordered_idx.cend()) {
+      // Get the next smallest dist, and corresponding j
+      long j;
+      float dist;
+      if (rr_it == rr_ordered_idx.cend() ||
+          (!qr_it == qr_ordered_idx.cend() &&
+           qr_dists[*qr_it] <= rr_dists[*rr_it])) {
+        j = *qr_it + nr_samples;
+        dist = qr_dists[*qr_it];
+        ++qr_it;
+      } else {
+        j = *rr_it;
+        dist = rr_dists[*rr_it];
+        ++rr_it;
+      }
+
+      if (j == i) {
+        continue;
+      }
+      bool new_val = abs(dist - prev_value) < epsilon;
+      if (unique_neighbors < kNN || new_val) {
+        dists.push_back(dist);
+        i_vec.push_back(i);
+        j_vec.push_back(j);
+        if (!new_val) {
+          unique_neighbors++;
+          prev_value = dist;
+        }
+      } else {
+        break; // next i
+      }
+    }
+  }
+  return (std::make_tuple(i_vec, j_vec, dists));
+}
+
+sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN) {}

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -120,8 +120,9 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
         break; // next i
       }
     }
-    len = dists.size();
+    len += dists.size();
   }
+  std::cout << len << std::endl;
 
   // Combine the lists from each thread
   std::vector<float> dists_all = combine_vectors(dists, len);

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -113,6 +113,7 @@ sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t n_samples,
   std::vector<long> i_vec;
   std::vector<long> j_vec;
   std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
+  const std::vector<long> j_sparse = std::get<1>(sparse_rr_mat);
   for (long i = 0; i < n_samples; ++i) {
     Eigen::Map<Eigen::VectorXf> rr_dists(dist_vec.data() + row_start_idx[i],
                                          row_start_idx[i + 1] -
@@ -123,7 +124,7 @@ sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t n_samples,
     float prev_value = -1;
     for (auto rr_it = rr_ordered_idx.cbegin(); rr_it != rr_ordered_idx.cend();
          ++rr_it) {
-      long j = *rr_it;
+      long j = std::get<1>(sparse_rr_mat)[row_start_idx[i] + *rr_it];
       float dist = rr_dists[*rr_it];
       if (j == i) {
         continue;

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -4,24 +4,16 @@
  * Functions to extend a sparse distance matrix
  *
  */
-#include <algorithm>
-#include <cassert> // assert
-#include <cmath>   // floor/sqrt
 #include <cstddef> // size_t
 #include <cstdint>
-#include <numeric>
-#include <string>
 #include <vector>
 
-#include "boundary.hpp"
+#include "extend.hpp"
 
-sparse_coo extend(const sparse_coo &sparse_rr_mat,
-                  const NumpyMatrix &qq_mat_square,
-                  const NumpyMatrix &qr_mat_rect, const size_t kNN) {
-  const size_t nr_samples = qr_mat_rect.rows();
-  const size_t nq_samples = qr_mat_rect.cols();
+const float epsilon = 1E-10;
 
-  // Get indices where each row starts in the sparse matrix
+// Get indices where each row starts in the sparse matrix
+std::vector<long> row_start_indices(const sparse_coo &sparse_rr_mat) {
   const std::vector<long> i_vec = std::get<0>(sparse_rr_mat);
   std::vector<long> row_start_idx(nr_samples + 1);
   size_t i_idx = 0;
@@ -33,6 +25,16 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
     }
     row_start_idx[i] = i_idx;
   }
+  return row_start_idx;
+}
+
+sparse_coo extend(const sparse_coo &sparse_rr_mat,
+                  const NumpyMatrix &qq_mat_square,
+                  const NumpyMatrix &qr_mat_rect, const size_t kNN) {
+  const size_t nr_samples = qr_mat_rect.rows();
+  const size_t nq_samples = qr_mat_rect.cols();
+
+  std::vector<long> row_start_idx = row_start_indices(sparse_rr_mat);
 
   // ijv vectors
   std::vector<float> dists;
@@ -54,10 +56,12 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
       qr_dists = qq_mat_square.row(i - nr_samples);
     }
 
-    // Sort these. Then do a merge
+    // Sort these. Then do a merge below
     std::vector<long> qr_ordered_idx = sort_indexes(qr_dists, 1);
     std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
 
+    // See sparsify_dists in pp_sketchlib.
+    // This is very similar, but merging two lists as input
     long unique_neighbors = 0;
     float prev_value = -1;
     auto rr_it = rr_ordered_idx.cbegin();
@@ -98,4 +102,42 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
   return (std::make_tuple(i_vec, j_vec, dists));
 }
 
-sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN) {}
+sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN) {
+  const size_t nr_samples = qr_mat_rect.rows();
+  std::vector<long> row_start_idx = row_start_indices(sparse_rr_mat);
+
+  // ijv vectors
+  std::vector<float> dists;
+  std::vector<long> i_vec;
+  std::vector<long> j_vec;
+  const std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
+  for (long i = 0; i < nr_samples; ++i) {
+    Eigen::Map<Eigen::VectorXf> rr_dists(dist_vec.data() + row_start_idx[i],
+                                           row_start_idx[i + 1] -
+                                               row_start_idx[i]);
+    std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
+
+    long unique_neighbors = 0;
+    float prev_value = -1;
+    for (long rr_it = rr_ordered_idx.cbegin(); rr_it != rr_ordered_idx.cend(); ++rr_it) {
+      long j = *rr_it;
+      float dist = rr_dists[*rr_it];
+      if (j == i) {
+        continue;
+      }
+      bool new_val = abs(dist - prev_value) < epsilon;
+      if (unique_neighbors < kNN || new_val) {
+        dists.push_back(dist);
+        i_vec.push_back(i);
+        j_vec.push_back(j);
+        if (!new_val) {
+          unique_neighbors++;
+          prev_value = dist;
+        }
+      } else {
+        break; // next i
+      }
+    }
+  }
+  return (std::make_tuple(i_vec, j_vec, dists));
+}

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -13,7 +13,8 @@
 const float epsilon = 1E-10;
 
 // Get indices where each row starts in the sparse matrix
-std::vector<long> row_start_indices(const sparse_coo &sparse_rr_mat) {
+std::vector<long> row_start_indices(const sparse_coo &sparse_rr_mat,
+                                    const size_t nr_samples) {
   const std::vector<long> i_vec = std::get<0>(sparse_rr_mat);
   std::vector<long> row_start_idx(nr_samples + 1);
   size_t i_idx = 0;
@@ -28,19 +29,19 @@ std::vector<long> row_start_indices(const sparse_coo &sparse_rr_mat) {
   return row_start_idx;
 }
 
-sparse_coo extend(const sparse_coo &sparse_rr_mat,
-                  const NumpyMatrix &qq_mat_square,
+sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_square,
                   const NumpyMatrix &qr_mat_rect, const size_t kNN) {
   const size_t nr_samples = qr_mat_rect.rows();
   const size_t nq_samples = qr_mat_rect.cols();
 
-  std::vector<long> row_start_idx = row_start_indices(sparse_rr_mat);
+  std::vector<long> row_start_idx =
+      row_start_indices(sparse_rr_mat, nr_samples);
 
   // ijv vectors
   std::vector<float> dists;
   std::vector<long> i_vec;
   std::vector<long> j_vec;
-  const std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
+  std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
   for (long i = 0; i < nr_samples + nq_samples; ++i) {
     // Extract the dists for the row from the qr (dense) and rr (sparse)
     // matrices
@@ -48,8 +49,8 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
     if (i < nr_samples) {
       qr_dists = qr_mat_rect.row(i);
       Eigen::Map<Eigen::VectorXf> rr_map(dist_vec.data() + row_start_idx[i],
-                                           row_start_idx[i + 1] -
-                                               row_start_idx[i]);
+                                         row_start_idx[i + 1] -
+                                             row_start_idx[i]);
       rr_dists = rr_map;
     } else {
       rr_dists = qr_mat_rect.col(i - nr_samples);
@@ -71,7 +72,7 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
       long j;
       float dist;
       if (rr_it == rr_ordered_idx.cend() ||
-          (!qr_it == qr_ordered_idx.cend() &&
+          (!(qr_it == qr_ordered_idx.cend()) &&
            qr_dists[*qr_it] <= rr_dists[*rr_it])) {
         j = *qr_it + nr_samples;
         dist = qr_dists[*qr_it];
@@ -102,24 +103,26 @@ sparse_coo extend(const sparse_coo &sparse_rr_mat,
   return (std::make_tuple(i_vec, j_vec, dists));
 }
 
-sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN) {
-  const size_t nr_samples = qr_mat_rect.rows();
-  std::vector<long> row_start_idx = row_start_indices(sparse_rr_mat);
+sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t n_samples,
+                      const size_t kNN) {
+  std::vector<long> row_start_idx =
+      row_start_indices(sparse_rr_mat, n_samples);
 
   // ijv vectors
   std::vector<float> dists;
   std::vector<long> i_vec;
   std::vector<long> j_vec;
-  const std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
-  for (long i = 0; i < nr_samples; ++i) {
+  std::vector<float> dist_vec = std::get<2>(sparse_rr_mat);
+  for (long i = 0; i < n_samples; ++i) {
     Eigen::Map<Eigen::VectorXf> rr_dists(dist_vec.data() + row_start_idx[i],
-                                           row_start_idx[i + 1] -
-                                               row_start_idx[i]);
+                                         row_start_idx[i + 1] -
+                                             row_start_idx[i]);
     std::vector<long> rr_ordered_idx = sort_indexes(rr_dists, 1);
 
     long unique_neighbors = 0;
     float prev_value = -1;
-    for (long rr_it = rr_ordered_idx.cbegin(); rr_it != rr_ordered_idx.cend(); ++rr_it) {
+    for (auto rr_it = rr_ordered_idx.cbegin(); rr_it != rr_ordered_idx.cend();
+         ++rr_it) {
       long j = *rr_it;
       float dist = rr_dists[*rr_it];
       if (j == i) {

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -5,8 +5,10 @@
 typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>>
     sparse_coo;
 
-sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_square,
-                  const NumpyMatrix &qr_mat_rect, const size_t kNN);
+sparse_coo extend(const sparse_coo &sparse_rr_mat,
+                  const NumpyMatrix &qq_mat_square,
+                  const NumpyMatrix &qr_mat_rect, const size_t kNN,
+                  const size_t num_threads);
 
 sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t n_samples,
                       const size_t kNN);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -2,8 +2,11 @@
 
 #include "boundary.hpp"
 
-sparse_coo extend(const sparse_coo &sparse_rr_mat,
-                  const NumpyMatrix &qq_mat_square,
+typedef std::tuple<std::vector<long>, std::vector<long>, std::vector<float>>
+    sparse_coo;
+
+sparse_coo extend(const sparse_coo &sparse_rr_mat, const NumpyMatrix &qq_mat_square,
                   const NumpyMatrix &qr_mat_rect, const size_t kNN);
 
-sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN);
+sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t n_samples,
+                      const size_t kNN);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "boundary.hpp"
+
+sparse_coo extend(const sparse_coo &sparse_rr_mat,
+                  const NumpyMatrix &qq_mat_square,
+                  const NumpyMatrix &qr_mat_rect, const size_t kNN);
+
+sparse_coo lower_rank(const sparse_coo &sparse_rr_mat, const size_t kNN);

--- a/src/python_bindings.cpp
+++ b/src/python_bindings.cpp
@@ -115,7 +115,8 @@ PYBIND11_MODULE(poppunk_refine, m) {
   m.def("extend", &extend, py::return_value_policy::reference_internal,
         "Extend a sparse distance matrix keeping k nearest-neighbours",
         py::arg("rr_mat"), py::arg("qq_mat").noconvert(),
-        py::arg("qr_mat").noconvert(), py::arg("kNN"));
+        py::arg("qr_mat").noconvert(), py::arg("kNN"),
+        py::arg("num_threads") = 1);
 
   m.def("lowerRank", &lower_rank, py::return_value_policy::reference_internal,
         "Extend a sparse distance matrix keeping k nearest-neighbours",

--- a/src/python_bindings.cpp
+++ b/src/python_bindings.cpp
@@ -12,6 +12,7 @@
 namespace py = pybind11;
 
 #include "boundary.hpp"
+#include "extend.hpp"
 
 // Wrapper which makes a ref to the python/numpy array
 Eigen::VectorXf assignThreshold(const Eigen::Ref<NumpyMatrix> &distMat,
@@ -31,27 +32,18 @@ edge_tuple edgeThreshold(const Eigen::Ref<NumpyMatrix> &distMat,
 }
 
 edge_tuple generateTuples(const std::vector<int> &assignments,
-                            const int within_label,
-                            bool self,
-                            const int num_ref,
-                            const int int_offset) {
-    edge_tuple edges = generate_tuples(assignments,
-                                        within_label,
-                                        self,
-                                        num_ref,
-                                        int_offset);
-    return (edges);
+                          const int within_label, bool self, const int num_ref,
+                          const int int_offset) {
+  edge_tuple edges =
+      generate_tuples(assignments, within_label, self, num_ref, int_offset);
+  return (edges);
 }
 
-edge_tuple generateAllTuples(const int num_ref,
-                                const int num_queries,
-                                bool self = true,
-                                const int int_offset = 0) {
-    edge_tuple edges = generate_all_tuples(num_ref,
-                                            num_queries,
-                                            self,
-                                            int_offset);
-    return (edges);
+edge_tuple generateAllTuples(const int num_ref, const int num_queries,
+                             bool self = true, const int int_offset = 0) {
+  edge_tuple edges =
+      generate_all_tuples(num_ref, num_queries, self, int_offset);
+  return (edges);
 }
 
 network_coo thresholdIterate1D(const Eigen::Ref<NumpyMatrix> &distMat,
@@ -99,21 +91,15 @@ PYBIND11_MODULE(poppunk_refine, m) {
 
   m.def("generateTuples", &generateTuples,
         py::return_value_policy::reference_internal,
-        "Return edge tuples based on assigned groups",
-        py::arg("assignments"),
-        py::arg("within_label"),
-        py::arg("self") = true,
-        py::arg("num_ref") = 0,
+        "Return edge tuples based on assigned groups", py::arg("assignments"),
+        py::arg("within_label"), py::arg("self") = true, py::arg("num_ref") = 0,
         py::arg("int_offset") = 0);
 
   m.def("generateAllTuples", &generateAllTuples,
-        py::return_value_policy::reference_internal,
-        "Return all edge tuples",
-        py::arg("num_ref"),
-        py::arg("num_queries") = 0,
-        py::arg("self") = true,
+        py::return_value_policy::reference_internal, "Return all edge tuples",
+        py::arg("num_ref"), py::arg("num_queries") = 0, py::arg("self") = true,
         py::arg("int_offset") = 0);
-    
+
   m.def("thresholdIterate1D", &thresholdIterate1D,
         py::return_value_policy::reference_internal,
         "Move a 2D boundary to grow a network by adding edges at each offset",
@@ -125,4 +111,13 @@ PYBIND11_MODULE(poppunk_refine, m) {
         py::return_value_policy::reference_internal,
         "Move a 2D boundary to grow a network by adding edges at each offset",
         py::arg("distMat").noconvert(), py::arg("x_max"), py::arg("y_max"));
+
+  m.def("extend", &extend, py::return_value_policy::reference_internal,
+        "Extend a sparse distance matrix keeping k nearest-neighbours",
+        py::arg("rr_mat"), py::arg("qq_mat").noconvert(),
+        py::arg("qr_mat").noconvert(), py::arg("kNN"));
+
+  m.def("lowerRank", &lower_rank, py::return_value_policy::reference_internal,
+        "Extend a sparse distance matrix keeping k nearest-neighbours",
+        py::arg("rr_mat"), py::arg("kNN"));
 }

--- a/src/python_bindings.cpp
+++ b/src/python_bindings.cpp
@@ -119,5 +119,5 @@ PYBIND11_MODULE(poppunk_refine, m) {
 
   m.def("lowerRank", &lower_rank, py::return_value_policy::reference_internal,
         "Extend a sparse distance matrix keeping k nearest-neighbours",
-        py::arg("rr_mat"), py::arg("kNN"));
+        py::arg("rr_mat"), py::arg("n_samples"), py::arg("kNN"));
 }

--- a/test/test-update.py
+++ b/test/test-update.py
@@ -24,20 +24,18 @@ else:
 def run_regression(x, y, threshold = 0.99):
     res = stats.linregress(x, y)
     print("R^2: " + str(res.rvalue**2))
-    #if res.rvalue**2 < threshold:
-    #    sys.stderr.write("Distance matrix order failed!\n")
-    #    sys.exit(1)
+    if res.rvalue**2 < threshold:
+        sys.stderr.write("Distance matrix order failed!\n")
+        sys.exit(1)
 
 def compare_sparse_matrices(d1,d2,r1,r2):
-    print(d1.todense())
-    print(d2.todense())
     d1_pairs = get_seq_tuples(d1.row,d1.col,r1)
     d2_pairs = get_seq_tuples(d2.row,d2.col,r2)
     d1_dists = []
     d2_dists = []
-    #if (len(d1_pairs) != len(d2_pairs)):
-    #    sys.stderr.write("Distance matrix number of entries differ!\n")
-    #    sys.exit(1)
+    if (len(d1_pairs) != len(d2_pairs)):
+        sys.stderr.write("Distance matrix number of entries differ!\n")
+        sys.exit(1)
 
     for (pair1,dist1) in zip(d1_pairs,d1.data):
         for (pair2,dist2) in zip(d2_pairs,d2.data):
@@ -46,8 +44,6 @@ def compare_sparse_matrices(d1,d2,r1,r2):
                 d2_dists.append(dist2)
                 break
 
-    print(len(d1_pairs))
-    print(len(d2_pairs))
     run_regression(np.asarray(d1_dists),np.asarray(d2_dists))
 
 def get_seq_tuples(rows,cols,names):

--- a/test/test-update.py
+++ b/test/test-update.py
@@ -122,3 +122,8 @@ S3 = scipy.sparse.load_npz("batch123/batch123_rank2_fit.npz")
 S4 = scipy.sparse.load_npz("batch3/batch3_rank2_fit.npz")
 
 compare_sparse_matrices(S3,S4,rlist3,rlist4)
+
+# Check rank 1
+S5 = scipy.sparse.load_npz("batch123/batch123_rank1_fit.npz")
+S6 = scipy.sparse.load_npz("batch3/batch3_rank1_fit.npz")
+compare_sparse_matrices(S5,S6,rlist3,rlist4)

--- a/test/test-update.py
+++ b/test/test-update.py
@@ -24,15 +24,20 @@ else:
 def run_regression(x, y, threshold = 0.99):
     res = stats.linregress(x, y)
     print("R^2: " + str(res.rvalue**2))
-    if res.rvalue**2 < threshold:
-        sys.stderr.write("Distance matrix order failed!\n")
-        sys.exit(1)
+    #if res.rvalue**2 < threshold:
+    #    sys.stderr.write("Distance matrix order failed!\n")
+    #    sys.exit(1)
 
 def compare_sparse_matrices(d1,d2,r1,r2):
+    print(d1.todense())
+    print(d2.todense())
     d1_pairs = get_seq_tuples(d1.row,d1.col,r1)
     d2_pairs = get_seq_tuples(d2.row,d2.col,r2)
     d1_dists = []
     d2_dists = []
+    #if (len(d1_pairs) != len(d2_pairs)):
+    #    sys.stderr.write("Distance matrix number of entries differ!\n")
+    #    sys.exit(1)
 
     for (pair1,dist1) in zip(d1_pairs,d1.data):
         for (pair2,dist2) in zip(d2_pairs,d2.data):
@@ -41,6 +46,8 @@ def compare_sparse_matrices(d1,d2,r1,r2):
                 d2_dists.append(dist2)
                 break
 
+    print(len(d1_pairs))
+    print(len(d2_pairs))
     run_regression(np.asarray(d1_dists),np.asarray(d2_dists))
 
 def get_seq_tuples(rows,cols,names):
@@ -91,6 +98,11 @@ S1 = scipy.sparse.load_npz("batch12/batch12_rank2_fit.npz")
 S2 = scipy.sparse.load_npz("batch2/batch2_rank2_fit.npz")
 compare_sparse_matrices(S1,S2,rlist1,rlist2)
 
+# Check rank 1
+S3 = scipy.sparse.load_npz("batch12/batch12_rank1_fit.npz")
+S4 = scipy.sparse.load_npz("batch2/batch2_rank1_fit.npz")
+compare_sparse_matrices(S3,S4,rlist1,rlist2)
+
 # Check distances after second query
 
 # Check that order is the same after doing 1 + 2 + 3 with --update-db, as doing all of 1 + 2 + 3 together
@@ -118,12 +130,12 @@ run_regression(X1[:, 1], X2[:, 1])
 # Check sparse distances after second query
 with open("batch123/batch123.dists.pkl", 'rb') as pickle_file:
     rlist3, qlist, self = pickle.load(pickle_file)
-S3 = scipy.sparse.load_npz("batch123/batch123_rank2_fit.npz")
-S4 = scipy.sparse.load_npz("batch3/batch3_rank2_fit.npz")
+S5 = scipy.sparse.load_npz("batch123/batch123_rank2_fit.npz")
+S6 = scipy.sparse.load_npz("batch3/batch3_rank2_fit.npz")
 
-compare_sparse_matrices(S3,S4,rlist3,rlist4)
+compare_sparse_matrices(S5,S6,rlist3,rlist4)
 
 # Check rank 1
-S5 = scipy.sparse.load_npz("batch123/batch123_rank1_fit.npz")
-S6 = scipy.sparse.load_npz("batch3/batch3_rank1_fit.npz")
-compare_sparse_matrices(S5,S6,rlist3,rlist4)
+S7 = scipy.sparse.load_npz("batch123/batch123_rank1_fit.npz")
+S8 = scipy.sparse.load_npz("batch3/batch3_rank1_fit.npz")
+compare_sparse_matrices(S7,S8,rlist3,rlist4)


### PR DESCRIPTION
This moves LineageFit.extend to the poppunk_refine extension. The algorithm is similar to that used in sparsifyDists in pp_sketchlib, but works specifically with a combination of sparse and dense matrices. The highest rank is computed, and then lowered to get smaller ranks. Parallelisation supported.